### PR TITLE
Making the install drive configurable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,12 +3,17 @@ gateway: 192.168.122.1
 netmask: 255.255.255.0
 # VMWare default ens192
 # KVM default ens3
+# Libvirt default enp1s0
 interface: ens192
 dns: 
   - 192.168.1.20
   - 192.168.2.20
 webserver_url: 192.168.1.20
 webserver_port: 8080
+
+# Drive to install RHCOS
+# Libvirt - can be vda
+install_drive: sda
 
 ocp_version: 4.3
 iso_checksum: 302081da24277ed752fee8d69839227f4f24ec71261f9dfe2752ea8c0f20a0ed

--- a/grub.cfg-single.j2
+++ b/grub.cfg-single.j2
@@ -24,7 +24,7 @@ set timeout=60
 # Menu list items start here
 {% for server in ansible_play_hosts_all|sort %}
 menuentry 'Install RHEL CoreOS {{ server }}' --class fedora --class gun-lunux --class gnu --class os {
-	linux /images/vmlinuz nomodeset rd.neednet=1 coreos.inst=yes ip={{ hostvars[server].ipv4 }}::{{ hostvars[server].gateway }}:{{ hostvars[server].netmask }}:{{ server }}:{{ hostvars[server].interface }}:none {% for myns in dns %}nameserver={{ myns }} {% endfor %}coreos.inst.install_dev=sda coreos.inst.image_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ rhcos_bios }} coreos.inst.ignition_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ hostvars[server].group_names[0] }}.ign
+	linux /images/vmlinuz nomodeset rd.neednet=1 coreos.inst=yes ip={{ hostvars[server].ipv4 }}::{{ hostvars[server].gateway }}:{{ hostvars[server].netmask }}:{{ server }}:{{ hostvars[server].interface }}:none {% for myns in dns %}nameserver={{ myns }} {% endfor %}coreos.inst.install_dev={{ install_drive | default(sda) }} coreos.inst.image_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ rhcos_bios }} coreos.inst.ignition_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ hostvars[server].group_names[0] }}.ign
 	initrd /images/initramfs.img
 }
 {% endfor %}

--- a/isolinux.cfg-single.j2
+++ b/isolinux.cfg-single.j2
@@ -69,6 +69,6 @@ menu separator # insert an empty line
 label Linux
   menu label ^Install on {{ server }}
   kernel /images/vmlinuz
-  append initrd=/images/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes ip={{ hostvars[server].ipv4 }}::{{ hostvars[server].gateway }}:{{ hostvars[server].netmask }}:{{ server }}:{{ hostvars[server].interface }}:none {% for myns in dns %}nameserver={{ myns }} {% endfor %}coreos.inst.install_dev=sda coreos.inst.image_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ rhcos_bios }} coreos.inst.ignition_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ hostvars[server].group_names[0] }}.ign
+  append initrd=/images/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes ip={{ hostvars[server].ipv4 }}::{{ hostvars[server].gateway }}:{{ hostvars[server].netmask }}:{{ server }}:{{ hostvars[server].interface }}:none {% for myns in dns %}nameserver={{ myns }} {% endfor %}coreos.inst.install_dev={{ install_drive | default(sda) }} coreos.inst.image_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ rhcos_bios }} coreos.inst.ignition_url={{ webserver_url }}:{{ webserver_port | default(80) }}/{{ hostvars[server].group_names[0] }}.ign
 {% endfor %}
 menu end

--- a/playbook-multi.yml
+++ b/playbook-multi.yml
@@ -68,7 +68,7 @@
 
   - name: Add install device name
     set_fact:
-      cmd_args: "{{ cmd_args }} coreos.inst.install_dev=sda"
+      cmd_args: "{{ cmd_args }} coreos.inst.install_dev={{ install_drive | default(sda) }}"
 
   - name: Add image_url
     set_fact:


### PR DESCRIPTION
Make the drive configurable for `coreos.inst.install_dev`. This `install_drive` is set in the `group_vars/all.yml`  file.

The default is to set it to `sda`