### PR TITLE
RHCOS raw disk image name is different in 4.5

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -22,5 +22,5 @@ install_drive: sda
 ocp_version: 4.5.2
 iso_checksum: 48e3cbbb632795f1cb4a5713d72c30b438a763468495db69c0a2ca7c7152856a
 iso_name: rhcos-{{ ocp_version }}-x86_64-installer.x86_64.iso
-rhcos_bios: rhcos-{{ ocp_version }}-x86_64-metal.raw.gz
+rhcos_bios: rhcos-{{ ocp_version }}-x86_64-metal.x86_64.raw.gz
 ...


### PR DESCRIPTION
The name of the raw disk image in 4.5 has the architecture (x86_64) added.