### PR TITLE
Master and Worker ignition files to singular + Check if ISO exists instead of download it each time

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -20,7 +20,7 @@ webserver_port: 8080
 install_drive: sda
 
 ocp_version: 4.4.3
-iso_checksum: 302081da24277ed752fee8d69839227f4f24ec71261f9dfe2752ea8c0f20a0ed
+iso_checksum: dc1287165ff5b9d10e729c5541b616d466a9f0ed2e3380d59490503758a4cb24
 iso_name: rhcos-{{ ocp_version }}-x86_64-installer.x86_64.iso
 rhcos_bios: rhcos-{{ ocp_version }}-x86_64-metal.raw.gz
 ...

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -20,7 +20,7 @@ webserver_port: 8080
 install_drive: sda
 
 ocp_version: 4.4.3
-iso_checksum: dc1287165ff5b9d10e729c5541b616d466a9f0ed2e3380d59490503758a4cb24
+iso_checksum: 302081da24277ed752fee8d69839227f4f24ec71261f9dfe2752ea8c0f20a0ed
 iso_name: rhcos-{{ ocp_version }}-x86_64-installer.x86_64.iso
 rhcos_bios: rhcos-{{ ocp_version }}-x86_64-metal.raw.gz
 ...

--- a/inventory.yml
+++ b/inventory.yml
@@ -6,7 +6,7 @@ all:
         bootstrap_node.example.com:
           ipv4: 192.168.122.15
     
-    masters:
+    master:
       hosts:
         master1.example.com:
           ipv4: 192.168.122.20
@@ -17,7 +17,7 @@ all:
         master3.example.com:
           ipv4: 192.168.122.22
         
-    workers:
+    worker:
       hosts:
         worker1.example.com:
           ipv4: 192.168.122.30

--- a/playbook-multi.yml
+++ b/playbook-multi.yml
@@ -18,11 +18,19 @@
   tasks:
 
   - block:
+    - name: Check if ISO is already available
+      stat:
+        path: /tmp/{{ iso_name }}
+        checksum_algorithm: sha256
+        get_checksum: yes
+      register: iso_file
+
     - name: Get the original ISO
       get_url:
         url: https://mirror.openshift.com/pub/openshift-v{{ ocp_version.split(".")[0] }}/dependencies/rhcos/{{ ocp_version.split(".")[0] }}.{{ ocp_version.split(".")[1] }}/{{ ocp_version }}/{{ iso_name }}
         dest: /tmp
         checksum: sha256:{{ iso_checksum }}
+      when: iso_file.stat.exists or iso_file.stat.checksum != iso_checksum
 
     - name: Mount ISO
       mount:

--- a/playbook-single.yml
+++ b/playbook-single.yml
@@ -16,13 +16,20 @@
       - genisoimage
 
   tasks:
-
   - block:
+    - name: Check if ISO is already available
+      stat:
+        path: /tmp/{{ iso_name }}
+        checksum_algorithm: sha256
+        get_checksum: yes
+      register: iso_file
+
     - name: Get the original ISO
       get_url:
         url: https://mirror.openshift.com/pub/openshift-v{{ ocp_version.split(".")[0] }}/dependencies/rhcos/{{ ocp_version.split(".")[0] }}.{{ ocp_version.split(".")[1] }}/{{ ocp_version }}/{{ iso_name }}
         dest: /tmp
         checksum: sha256:{{ iso_checksum }}
+      when: iso_file.stat.exists or iso_file.stat.checksum != iso_checksum
 
     - name: Mount ISO
       mount:


### PR DESCRIPTION
With master**s** and worker**s** as group in sample inventory.yml file, grub.cfg ends up with master**s**.ign and worker**s*.ign url. This is not synced with openshift-install generated ignition files that come in singular.

ISO download each time playbook is called is rather annoying, so second proposition checks is file is already present and validates against provided checksum.