### PR TITLE
Adding timeout var

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -22,6 +22,10 @@ webserver_ignition_path: ignition
 # Libvirt - can be vda
 install_drive: sda
 
+# Timeout for selection menu during first boot
+# '-1' for infinite timeout. Default '10'
+boot_timeout: 10
+
 # Chose the binary architecture
 # x86_64 or ppc64le
 arch: "x86_64"

--- a/grub.cfg-multi.j2
+++ b/grub.cfg-multi.j2
@@ -1,8 +1,6 @@
 # This file is copied from
 # https://github.com/coreos/fedora-coreos-config
 
-set default="1"
-
 function load_video {
   insmod efi_gop
   insmod efi_uga
@@ -17,7 +15,7 @@ insmod gzio
 insmod part_gpt
 insmod ext2
 
-set timeout=10
+set timeout={{ boot_timeout }}
 set default=0
 ### END /etc/grub.d/00_header ###
 

--- a/grub.cfg-single-ppc64.j2
+++ b/grub.cfg-single-ppc64.j2
@@ -1,8 +1,6 @@
 # This file is copied from
 # https://github.com/coreos/fedora-coreos-config
 
-set default="1"
-
 function load_video {
   insmod efi_gop
   insmod efi_uga
@@ -17,7 +15,8 @@ insmod gzio
 insmod part_gpt
 insmod ext2
 
-set timeout=60
+set timeout={{ boot_timeout }}
+set default=0
 ### END /etc/grub.d/00_header ###
 
 ### BEGIN /etc/grub.d/10_linux ###

--- a/grub.cfg-single.j2
+++ b/grub.cfg-single.j2
@@ -1,8 +1,6 @@
 # This file is copied from
 # https://github.com/coreos/fedora-coreos-config
 
-set default="1"
-
 function load_video {
   insmod efi_gop
   insmod efi_uga
@@ -17,7 +15,8 @@ insmod gzio
 insmod part_gpt
 insmod ext2
 
-set timeout=60
+set timeout={{ boot_timeout }}
+set default=0
 ### END /etc/grub.d/00_header ###
 
 ### BEGIN /etc/grub.d/10_linux ###

--- a/isolinux.cfg-multi.j2
+++ b/isolinux.cfg-multi.j2
@@ -3,7 +3,7 @@
 # changes.
 serial 0
 default vesamenu.c32
-timeout 100
+timeout {{ boot_timeout }}
 
 display boot.msg
 

--- a/isolinux.cfg-single.j2
+++ b/isolinux.cfg-single.j2
@@ -3,7 +3,7 @@
 # changes.
 serial 0
 default vesamenu.c32
-timeout 600
+timeout {{ boot_timeout }}
 
 display boot.msg
 


### PR DESCRIPTION
An infinite timeout can prevent a master re-installing itself after rebooting and destroying cluster.
I hava manually changed this value for some iso generation and though it could be usefull.