### PR TITLE
full path for the root device to be used for installation

### DIFF
--- a/arguments.j2
+++ b/arguments.j2
@@ -3,7 +3,7 @@ rd.luks.options=discard {# -#}
 coreos.liveiso=RHCOS-CustomIso {# -#}
 ignition.firstboot {# -#}
 ignition.platform.id=metal {# -#}
-coreos.inst.install_dev={{ install_drive | default(sda) }} {# -#}
+coreos.inst.install_dev=/dev/{{ install_drive | default(sda) }} {# -#}
 coreos.inst.ignition_url={{ webserver_ignition_fullpath }}{{ hostvars[server].group_names[0] }}.ign {# -#}
 {%- if hostvars[server].interfaces is defined -%}
   {%- for intf_name, intf in hostvars[server].interfaces.items() -%}


### PR DESCRIPTION
Just added the new struct for devices.
CoreOS now uses /dev/{dev-name} instead of just {dev-name}